### PR TITLE
Ajout boutons  sauvegarder et supprimer en bas des commandes orvibo

### DIFF
--- a/desktop/php/orvibo.php
+++ b/desktop/php/orvibo.php
@@ -203,6 +203,14 @@ $eqLogics = eqLogic::byType('orvibo');
       </tbody>
     </table>
 
+  <form class="form-horizontal">
+    <fieldset>
+        <div class="form-actions">
+            <a class="btn btn-danger eqLogicAction" data-action="remove"><i class="fa fa-minus-circle"></i> {{Supprimer}}</a>
+            <a class="btn btn-success eqLogicAction" data-action="save"><i class="fa fa-check-circle"></i> {{Sauvegarder}}</a>
+        </div>
+    </fieldset>
+</form>
   </div>
   </div>
   </div>


### PR DESCRIPTION
Ajout des boutons sauvegarder et supprimer au bas du tableau de commandes qui ont été retirés pour une raison que je connais pas. (Boutons utiles lorsque l'on a un long tableau de commande  ( +100) ce qui évite de revenir en haut de page pour sauvegarder.